### PR TITLE
Add item name to access request vitor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ flask_session/
 *.pyc
 data_import/local_db/
 data_import/export*
+*.db
+glottolog_lookup.json

--- a/templates/mlc_ucla_search/sidebar-right.html
+++ b/templates/mlc_ucla_search/sidebar-right.html
@@ -47,20 +47,24 @@
               <a href="/Shibboleth.sso/Logout"><i class="fa fa-user-circle-o" aria-hidden="true"></i> {% trans %}Log out{% endtrans %}</a><br>
             </li>
           {% endif %}
-          {% if is_restricted%}
-            {% if cnet_id%}
-              <li>
-                <form action="/send-cgimail" method="POST">
-                  <input type="hidden" name="msg_type" value="request_access">
-                  <input type="hidden" name="CNET ID" value="{{ cnet_id }}" required>
-                  <input type="hidden" name="Series ID" value="{{ series_id }}" required>
-                  <button type="submit">{% trans %}Request Access to this Series/Item{% endtrans %}</button><br>
-                </form>
-              </li>
-            {% else %}
-              <li>
-                <button onclick="alert('{% trans %}Request an account before requesting access.{% endtrans %}')">{% trans %}Request Access to this Series/Item{% endtrans %}</button>
-              </li>
+          {% if request_access_button %}
+            {% if request_access_button.show %}
+              {% if cnet_id%}
+                <li>
+                  <form action="/send-cgimail" method="POST">
+                    <input type="hidden" name="msg_type" value="request_access">
+                    <input type="hidden" name="CNET ID" value="{{ cnet_id }}" required>
+                    <input type="hidden" name="Series ID" value="{{ request_access_button.series_id }}" required>
+                    <input type="hidden" name="Item ID" value="{{ request_access_button.item_id }}" required>
+                    <input type="hidden" name="Item Title" value="{{ request_access_button.item_title }}" required>
+                    <button type="submit">{% trans %}Request Access to this Series{% endtrans %}</button><br>
+                  </form>
+                </li>
+              {% else %}
+                <li>
+                  <button onclick="alert('{% trans %}Request an account before requesting access.{% endtrans %}')">{% trans %}Request Access to this Series{% endtrans %}</button>
+                </li>
+              {% endif %}
             {% endif %}
           {% endif %}
           <li>


### PR DESCRIPTION
We found that it's hard to find a series using only the series identifier in Panopto. It's also difficult to search for the series name. The easiest way for an SCRC staff to find the relevant series is to search for the item name and click on the series link next to it in the search results. So this information needs to be provided.
- [x]  Find an item to include the id and the title in the request when a user asks for access to a series from the series page.
- [x]  Create a new dictionary to centralize all the details required for the ‘Request Access’ button
- [x]  Include a `show` parameter to trigger `False` when: `series_is_restricted AND (series_has_no_item_with_panopto_link OR item_has_no_panopto_link)`
    - if an item has no panopto link, but there is an item in the series with a panopto link the ‘Request Access’ button will not be displayed
    - the button will still display for users already with access to the resource
- [x]  Remove ‘item’ from the request access button string
- [x]  Add copy in the cgimail receipt for ‘Request Access’ suggesting users to keep a record of the requests they make and avoid duplicates.

### Links for testing
- Series without a panopto /series/b2jt29x3v493
- Item without a panopto /item/b2468m46hz76
- Series with a panopto /series/b2md1k43rm6m
- Item with a panopto /item/b26t3jp06w5n