### PR TITLE
improved representation of descendant items in item view

### DIFF
--- a/mlc_ucla_search.py
+++ b/mlc_ucla_search.py
@@ -483,14 +483,15 @@ def series(noid):
     item_title_with_panopto = ''
     grouped_items = {}
     for i in items:
-        medium = i[1]['medium'][0]
-        if medium not in grouped_items:
-            grouped_items[medium] = []        
-        grouped_items[medium].append(i[1])
-        if i[1]['panopto_identifiers'] and i[1]['panopto_identifiers']:
-            has_panopto = True
-            item_id_with_panopto = i[1]['identifier'][0]
-            item_title_with_panopto = i[1]['titles'][0]
+        if not i[1]['is_format_of']:
+            medium = i[1]['medium'][0]
+            if medium not in grouped_items:
+                grouped_items[medium] = []        
+            grouped_items[medium].append(i[1])
+            if i[1]['panopto_identifiers'] and i[1]['panopto_identifiers']:
+                has_panopto = True
+                item_id_with_panopto = i[1]['identifier'][0]
+                item_title_with_panopto = i[1]['titles'][0]
 
     try:
         title_slug = ' '.join(series_data['titles'])
@@ -512,6 +513,7 @@ def series(noid):
         **(series_data | {
             'grouped_items': grouped_items,
             'title_slug': title_slug,
+            'order_of_formats' : ["Sound", "(:unav)", "image", "MP4", "video", "video_file", "Laser Disc", "Slide", "1/4 inch audio tape", "1/8 inch Audio Cassette", "1/8 inch audio cassette", "CD", "DAT", "DVD", "Film", "Image", "Microform", "Record", "Text", "VHS", "1/8 inch audio Cassette", "Cylinder", "LP Record", "LP Record (45)", "MiniDV", "U-Matic", "Video8", "Wire"],
             'request_access_button' : request_access_button,
             'access_rights': get_access_label_obj(series_data)
         })
@@ -563,24 +565,6 @@ def item(noid):
         item_data['titles'][0]
     )
 
-    # Converted Mediums
-    # for medium, converted_items in item_data['has_format'].items():
-    #     converted_items.sort(key=sortListOfItemsByID)
-    #     # recursive items
-    #     # Converted Items
-    #     for conv_ind in range(len(converted_items)):
-    #         converted_item = converted_items[conv_ind]
-    #         # Recursive Converted Mediums
-    #         for hf_medium, rec_item_links in converted_item['has_format'].items():
-    #             # Recursive Converted items
-    #             for rec_ind in range(len(rec_item_links)):
-    #                 rec_item_link = rec_item_links[rec_ind]
-    #                 if isinstance(rec_item_link,str) and rec_item_link.find("ark:61001/"):
-    #                     nid = rec_item_link.split("ark:61001/",1)[1]
-    #                     item_data['has_format'][medium][conv_ind]['has_format'][hf_medium][rec_ind] = mlc_db.get_item(BASE + nid, True)
-    # for medium, items in item_data['is_format_of'].items():
-    #     items.sort(key=sortListOfItemsByID)
-
     # Descendats
     if len(item_data['descendants'])>0:
         for level, formats in item_data['descendants'].items():
@@ -596,6 +580,7 @@ def item(noid):
             'access_rights': get_access_label_obj(item_data),
             'request_access_button' : request_access_button,
             'panopto_identifier': panopto_identifier,
+            'order_of_formats' : ["Sound", "(:unav)", "image", "MP4", "video", "video_file", "Laser Disc", "Slide", "1/4 inch audio tape", "1/8 inch Audio Cassette", "1/8 inch audio cassette", "CD", "DAT", "DVD", "Film", "Image", "Microform", "Record", "Text", "VHS", "1/8 inch audio Cassette", "Cylinder", "LP Record", "LP Record (45)", "MiniDV", "U-Matic", "Video8", "Wire"],
             'breadcrumb': breadcrumb})
     )
 

--- a/mlc_ucla_search.py
+++ b/mlc_ucla_search.py
@@ -570,8 +570,11 @@ def item(noid):
         for level, formats in item_data['descendants'].items():
             for medium, item_list in formats.items():
                 for k, item in enumerate(item_list):
-                    item_data['descendants'][level][medium][k] = mlc_db.get_item(item)
-
+                    fetched_item = mlc_db.get_item(item)
+                    if item_data['identifier'][0] != fetched_item['identifier'][0]:
+                        item_data['descendants'][level][medium][k] = mlc_db.get_item(item)
+                    else:
+                        item_data['descendants'][level][medium].pop(k)
 
     return render_template(
         'item.html',

--- a/mlc_ucla_search.py
+++ b/mlc_ucla_search.py
@@ -438,7 +438,7 @@ def search():
         for i in db_series[1]:
             info = mlc_db.get_item(i)
             series_data['sub_items'].append(info)
-        series_data['sub_items'].sort(key=sortListOfItems)
+        series_data['sub_items'].sort(key=sortListOfItemsByID)
         processed_results.append((db_series[0], series_data))
 
     if facets:
@@ -491,8 +491,6 @@ def series(noid):
             has_panopto = True
             item_id_with_panopto = i[1]['identifier'][0]
             item_title_with_panopto = i[1]['titles'][0]
-    # for medium, items in grouped_items.items():
-    #     items.sort(key=sortListOfItemsByID)
 
     try:
         title_slug = ' '.join(series_data['titles'])
@@ -553,6 +551,19 @@ def item(noid):
         'item_id' : item_data['identifier'][0],
         'item_title' : item_data['titles'][0] or 'Unknow item title',
     }
+    for medium, converted_items in item_data['has_format'].items():
+        converted_items.sort(key=sortListOfItemsByID)
+        # recursive items
+        for conv_ind in range(len(converted_items)):
+            converted_item = converted_items[conv_ind]
+            for hf_medium, rec_item_links in converted_item['has_format'].items():
+                for rec_ind in range(len(rec_item_links)):
+                    rec_item_link = rec_item_links[rec_ind]
+                    if isinstance(rec_item_link,str) and rec_item_link.find("ark:61001/"):
+                        nid = rec_item_link.split("ark:61001/",1)[1]
+                        item_data['has_format'][medium][conv_ind]['has_format'][hf_medium][rec_ind] = mlc_db.get_item(BASE + nid, True)
+    for medium, items in item_data['is_format_of'].items():
+        items.sort(key=sortListOfItemsByID)
 
     try:
         title_slug = item_data['titles'][0]

--- a/mlc_ucla_search.py
+++ b/mlc_ucla_search.py
@@ -551,12 +551,16 @@ def item(noid):
         'item_id' : item_data['identifier'][0],
         'item_title' : item_data['titles'][0] or 'Unknow item title',
     }
+    # Converted Mediums
     for medium, converted_items in item_data['has_format'].items():
         converted_items.sort(key=sortListOfItemsByID)
         # recursive items
+        # Converted Items
         for conv_ind in range(len(converted_items)):
             converted_item = converted_items[conv_ind]
+            # Recursive Converted Mediums
             for hf_medium, rec_item_links in converted_item['has_format'].items():
+                # Recursive Converted items
                 for rec_ind in range(len(rec_item_links)):
                     rec_item_link = rec_item_links[rec_ind]
                     if isinstance(rec_item_link,str) and rec_item_link.find("ark:61001/"):

--- a/mlc_ucla_search.py
+++ b/mlc_ucla_search.py
@@ -476,7 +476,6 @@ def series(noid):
             i,
             mlc_db.get_item(i)
         ))
-    items.sort(key=sortListOfItemsByID)
 
     has_panopto = False # to display the Request Access button
     item_id_with_panopto = ''
@@ -492,6 +491,8 @@ def series(noid):
                 has_panopto = True
                 item_id_with_panopto = i[1]['identifier'][0]
                 item_title_with_panopto = i[1]['titles'][0]
+    for medium, item_list in grouped_items.items():
+        grouped_items[medium].sort(key=sortListOfItemsByID)
 
     try:
         title_slug = ' '.join(series_data['titles'])
@@ -575,6 +576,9 @@ def item(noid):
                         item_data['descendants'][level][medium][k] = mlc_db.get_item(item)
                     else:
                         item_data['descendants'][level][medium].pop(k)
+        for level, formats in item_data['descendants'].items():
+            for medium, item_list in formats.items():
+                item_data['descendants'][level][medium].sort(key=sortListOfItemsByID)
 
     return render_template(
         'item.html',

--- a/mlc_ucla_search.py
+++ b/mlc_ucla_search.py
@@ -312,6 +312,11 @@ def sortListOfItems(item):
     else:
         return 2
 
+def sortListOfItemsByID(item):
+    if isinstance(item, tuple):
+        item = item[1]
+    return int(item['identifier'][0])
+
 def get_access_label_obj(item):
     # list of results
     #   tuple for item
@@ -471,7 +476,7 @@ def series(noid):
             i,
             mlc_db.get_item(i)
         ))
-    items.sort(key=sortListOfItems)
+    items.sort(key=sortListOfItemsByID)
 
     has_panopto = False # to display the Request Access button
     item_id_with_panopto = ''
@@ -486,6 +491,8 @@ def series(noid):
             has_panopto = True
             item_id_with_panopto = i[1]['identifier'][0]
             item_title_with_panopto = i[1]['titles'][0]
+    # for medium, items in grouped_items.items():
+    #     items.sort(key=sortListOfItemsByID)
 
     try:
         title_slug = ' '.join(series_data['titles'])

--- a/static/css/mlc.css
+++ b/static/css/mlc.css
@@ -324,12 +324,9 @@ ul.no-style-list{
 /* ITEMS */
 .items-listing{
 	margin: 0;
-	/*box-shadow: inset 0 30px 24px -30px #dadada;
-  padding-top: 7px;*/
 }
 .items-listing .item-card{
 	display: block;
-	margin-bottom: .3rem;
 	margin-bottom: .5rem;
 	border: 1px solid #eee;
 	border-radius: .5rem;
@@ -340,15 +337,27 @@ ul.no-style-list{
 	color: black;
 	text-decoration: none !important;
 }
-.text-muted-extra{
-	color: #757575 !important;
+.items-listing .item-card:active,
+.items-listing .item-card:focus,
+.items-listing .item-card:hover{
+	box-shadow: 1px 2px 4px #d9d9d9;
+	text-decoration: none !important;
 }
-.items-listing .item-card span.item-card-title{
+
+.items-listing .item-card .item-card-title-row{
+	display: flex;
+}
+
+.items-listing .item-card .item-card-title{
 	width: 100%;
   /* white-space: nowrap;*/
 	/* overflow: hidden;*/
 	/* text-overflow: ellipsis;*/
+	font-size: inherit;
+	font-weight: inherit;
+	color: inherit;
 	height: 3.3rem;
+	margin:0;
   padding-top: 5px;
   padding-right: 3px;
   display: -webkit-box;
@@ -356,39 +365,32 @@ ul.no-style-list{
   -webkit-box-orient: vertical;
   overflow: hidden;
 }
-.items-listing .item-card:active span.item-card-title,
-.items-listing .item-card:focus span.item-card-title,
-.items-listing .item-card:hover span.item-card-title{
+.items-listing .item-card:active .item-card-title,
+.items-listing .item-card:focus .item-card-title,
+.items-listing .item-card:hover .item-card-title{
 	text-decoration: underline;
 }
-.items-listing .item-card:active,
-.items-listing .item-card:focus,
-.items-listing .item-card:hover{
-	box-shadow: 1px 2px 4px #d9d9d9;
-	text-decoration: none !important;
-}
-.items-listing .item-card .item-card-title-row,
-.items-listing .item-card .item-card-content-row{
+
+.items-listing .item-card .item-card-content-row {
 	display: flex;
+	flex-wrap: wrap
 }
-.items-listing .item-card .item-card-content-row{
-	align-items: flex-end;
-}
-/*.items-listing .item-card .item-card-title-row>*:first-child,*/
-.items-listing .item-card .item-card-content-row>*:first-child {
-  flex-grow: 1;
-  max-width: 100%;
+.items-listing .item-card .item-card-content-row>* {
   white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  padding-right: 1rem;
+	overflow: hidden;
+/*	text-overflow: ellipsis;*/
 }
-.items-listing .item-card .item-card-content-row p{
-  margin: 0;
+.items-listing .item-card .item-card-content-row>*:last-child {
+  flex-grow: 1;
+  text-align: right;
 }
 .items-listing .item-card .item-card-title-row .item-icon{
   top: .3rem;
   position: relative;
+}
+
+.text-muted-extra{
+	color: #757575 !important;
 }
 @media (min-width:500px) and (max-width:992px){
 	.items-listing li{

--- a/static/css/mlc.css
+++ b/static/css/mlc.css
@@ -324,6 +324,8 @@ ul.no-style-list{
 /* ITEMS */
 .items-listing{
 	margin: 0;
+	/*box-shadow: inset 0 30px 24px -30px #dadada;
+  padding-top: 7px;*/
 }
 .items-listing .item-card{
 	display: block;

--- a/static/css/mlc.css
+++ b/static/css/mlc.css
@@ -327,7 +327,7 @@ ul.no-style-list{
 }
 .items-listing .item-card{
 	display: block;
-	margin-bottom: .5rem;
+	margin-bottom: 18px;
 	border: 1px solid #eee;
 	border-radius: .5rem;
 	padding: .3rem .5rem;

--- a/static/css/mlc.css
+++ b/static/css/mlc.css
@@ -356,12 +356,12 @@ ul.no-style-list{
 	font-size: inherit;
 	font-weight: inherit;
 	color: inherit;
-	height: 3.3rem;
+	height: 4.6rem;
 	margin:0;
   padding-top: 5px;
   padding-right: 3px;
   display: -webkit-box;
-  -webkit-line-clamp: 2;
+  -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
   overflow: hidden;
 }

--- a/static/css/mlc.css
+++ b/static/css/mlc.css
@@ -342,12 +342,17 @@ ul.no-style-list{
 	color: #757575 !important;
 }
 .items-listing .item-card span.item-card-title{
-	max-width: 100%;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+	width: 100%;
+  /* white-space: nowrap;*/
+	/* overflow: hidden;*/
+	/* text-overflow: ellipsis;*/
+	height: 3.3rem;
   padding-top: 5px;
   padding-right: 3px;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 .items-listing .item-card:active span.item-card-title,
 .items-listing .item-card:focus span.item-card-title,
@@ -367,7 +372,7 @@ ul.no-style-list{
 .items-listing .item-card .item-card-content-row{
 	align-items: flex-end;
 }
-.items-listing .item-card .item-card-title-row>*:first-child,
+/*.items-listing .item-card .item-card-title-row>*:first-child,*/
 .items-listing .item-card .item-card-content-row>*:first-child {
   flex-grow: 1;
   max-width: 100%;

--- a/templates/mlc_ucla_search/component-item-in-list.html
+++ b/templates/mlc_ucla_search/component-item-in-list.html
@@ -31,9 +31,5 @@
       </span>
       <span class="text-muted-extra">{{ item.identifier.0 }}</span>
     </div>
-    {# 
-    <p>{{ item.is_format_of|length }}</p>
-    <pre>{{ item.is_format_of }}</pre> 
-    #}
   </a>
 </li>

--- a/templates/mlc_ucla_search/component-item-in-list.html
+++ b/templates/mlc_ucla_search/component-item-in-list.html
@@ -16,7 +16,7 @@
           {{ medium }}
         {% endfor %}
         {% if item.has_format|length > 0 %}
-          <span title="{% trans %}Item has further conversions{% endtrans %}">+</span>
+          <span title="{% trans %}Item has further conversions{% endtrans %}">(+)</span>
         {% endif %}
           &nbsp;
       </span>

--- a/templates/mlc_ucla_search/component-item-in-list.html
+++ b/templates/mlc_ucla_search/component-item-in-list.html
@@ -31,5 +31,9 @@
       </span>
       <span class="text-muted-extra">{{ item.identifier.0 }}</span>
     </div>
+    {# 
+    <p>{{ item.is_format_of|length }}</p>
+    <pre>{{ item.is_format_of }}</pre> 
+    #}
   </a>
 </li>

--- a/templates/mlc_ucla_search/component-item-in-list.html
+++ b/templates/mlc_ucla_search/component-item-in-list.html
@@ -1,35 +1,34 @@
 <li class="col-xs-12 col-md-6 col-lg-4" title="{{item.titles[0]}}">
   <a class="item-card" href="/item/{{ item.ark|replace('https://ark.lib.uchicago.edu/ark:61001/', '')|urlencode }}/">
     <div class="item-card-title-row">
-      <span class="item-card-title">
+      <h3 class="item-card-title">
         {% for title in item.titles %}
           {{ title }}
         {% endfor %}
-      </span>
+      </h3>
       {% if item.panopto_links|length > 0 %}
-        <span title="item has digital content"><i class="item-icon fa fa-lg fa-file-audio-o" aria-hidden="true"></i></span>
+        <span title="{% trans %}item has digital content{% endtrans %}"><i class="item-icon fa fa-lg fa-file-audio-o" aria-hidden="true"></i></span>
       {% endif %}
     </div>
     <div class="item-card-content-row">
-      <span title="Type of Media">
-      {% for medium in item.medium %}
-        {{ medium }}
-      {% endfor %}
+      <span title="{% trans %}Type of Media{% endtrans %}">
+        {% for medium in item.medium %}
+          {{ medium }}
+        {% endfor %}
+        {% if item.has_format|length > 0 %}
+          <span title="{% trans %}Item has further conversions{% endtrans %}">+</span>
+        {% endif %}
+          &nbsp;
       </span>
-      {% if item.has_format|length > 0 %}
-        <span title="Item is converted to other formats">+<i class="fa fa-files-o" aria-hidden="true"></i></span>
+      {% if item.subject_language %}
+        <span title="{% trans %}Subject Language{% endtrans %}">
+            <i class="fa fa-language text-muted-extra" aria-hidden="true"></i>
+            {% for lan in item.subject_language %}
+              {{ lan }}{{ ", " if not loop.last else "" }}
+            {% endfor %}
+        </span>
       {% endif %}
-    </div>
-    <div class="item-card-content-row">
-        <span title="Subject language">
-        {% if item.subject_language %}
-          <i class="fa fa-language text-muted-extra" aria-hidden="true"></i>
-          {% for lan in item.subject_language %}
-            {{ lan }}{{ ", " if not loop.last else "" }}
-          {% endfor %}
-        {%  endif %}
-      </span>
-      <span class="text-muted-extra">{{ item.identifier.0 }}</span>
+      <span title="{% trans %}Record Identifier{% endtrans %}" class="text-muted-extra">{{ item.identifier.0 }}</span>
     </div>
   </a>
 </li>

--- a/templates/mlc_ucla_search/item.html
+++ b/templates/mlc_ucla_search/item.html
@@ -199,23 +199,23 @@
                 </a>
 
                 {% if item.has_format|length>0 %}
-                  <h4>Further converted to</h4>
-                  <div style="padding-left:1rem">
-                  {% for rec_medium, rec_item_list in item.has_format.items() %}
-                    <h5>{{ rec_medium }}</h5>
-                    <div class="items-listing">
-                      <div class="row">
-                        <ul class="no-style-list">
-                        {% for rec_item in rec_item_list %}
-                          {% with %}
-                            {% set item = rec_item %}
-                            {% include 'component-item-in-list.html' %}
-                          {% endwith %}
-                        {% endfor %}
-                        </ul>
+                  <div style="margin-left: .2rem;border-left: 1px solid #eee;padding-left:.8rem; margin-bottom: 1rem; border-bottom-left-radius: 8px;">
+                    <h4 style="margin-top:0">Further converted to</h4>
+                    {% for rec_medium, rec_item_list in item.has_format.items() %}
+                      <h5>{{ rec_medium }}</h5>
+                      <div class="items-listing">
+                        <div class="row">
+                          <ul class="no-style-list">
+                          {% for rec_item in rec_item_list %}
+                            {% with %}
+                              {% set item = rec_item %}
+                              {% include 'component-item-in-list.html' %}
+                            {% endwith %}
+                          {% endfor %}
+                          </ul>
+                        </div>
                       </div>
-                    </div>
-                  {% endfor %}
+                    {% endfor %}
                   </div>
                 {% endif %}
               </li>

--- a/templates/mlc_ucla_search/item.html
+++ b/templates/mlc_ucla_search/item.html
@@ -162,7 +162,7 @@
             <h2>{% trans %}And further converted:{% endtrans %}</h2>
             <div class="items-listing">
           {% elif level > 2 %}
-            <div class="items-listing" style="padding-left:.5rem; border-left: 1px solid #a6a6a6; border-bottom-left-radius: 8px;">
+            <div class="items-listing" style="padding:.5rem 0 0 .5rem; border-left: 1px solid #a6a6a6; border-bottom-left-radius: 8px;">
           {% endif %}
            {# <span class="text-muted">Gen: {{ level }}</span> #}
             <div class="row">

--- a/templates/mlc_ucla_search/item.html
+++ b/templates/mlc_ucla_search/item.html
@@ -155,22 +155,20 @@
     </ul>
 
     {% if descendants|length >0 %}
-      <h2>{% trans %}Has been converted to{% endtrans %}</h2>
+      <h2>{% trans %}This item has been converted to the following items:{% endtrans %}</h2>
       <div class="items-listing" >
-        {% for level, formats in descendants.items() %} 
-          {% if level > 1 %}
-            <div class="items-listing" style="padding-left:.5rem; border-left: 1px solid #eee;">
+        {% for level, formats in descendants.items() %}
+          {% if level == 2 %}
+            <h2>{% trans %}And further converted:{% endtrans %}</h2>
+            <div class="items-listing">
+          {% elif level > 2 %}
+            <div class="items-listing" style="padding-left:.5rem; border-left: 1px solid #a6a6a6; border-bottom-left-radius: 8px;">
           {% endif %}
-           <span class="text-muted">Gen: {{ level }}</span>
+           {# <span class="text-muted">Gen: {{ level }}</span> #}
             <div class="row">
               <ul class="no-style-list">
               {% for format, item_list in formats.items() %}
                   {% for descendant in item_list %}
-                    {#
-                    <pre>{{ item }}</pre>
-                    {% set item = item_o[1] %}
-                    #}
-
                     {% set item = descendant %}
                     {% include 'component-item-in-list.html' %}
                   {% endfor %}
@@ -178,101 +176,28 @@
               </ul>
             </div>
         {% endfor %}
-        {% for level, formats in descendants.items() %}
+        {% for l in descendants %}
           </div>
         {% endfor %}
-      {#
-       {% for medium, item_list in has_format.items() %}
-        <h3>{{ medium }}</h3>
-        <div class="items-listing">
-            <ul class="no-style-list">
-            {% for item in item_list %}
-              <li title="{{item.titles[0]}}">
-
-                <a class="item-card" href="/item/{{ item.ark|replace('https://ark.lib.uchicago.edu/ark:61001/', '')|urlencode }}/">
-                  <div class="item-card-title-row">
-                    <span class="item-card-title">
-                      {% for title in item.titles %}
-                        {{ title }}
-                      {% endfor %}
-                    </span>
-                    {% if item.panopto_links|length > 0 %}
-                      <span title="item has digital content"><i class="item-icon fa fa-lg fa-file-audio-o" aria-hidden="true"></i></span>
-                    {% endif %}
-                  </div>
-                  <div class="item-card-content-row">
-                    <span title="Type of Media">
-                    {% for medium in item.medium %}
-                      {{ medium }}
-                    {% endfor %}
-                    </span>
-                    {% if item.has_format|length > 0 %}
-                      <span title="Item is converted to other formats">+<i class="fa fa-files-o" aria-hidden="true"></i></span>
-                    {% endif %}
-                  </div>
-                  <div class="item-card-content-row">
-                      <span title="Subject language">
-                      {% if item.subject_language %}
-                        <i class="fa fa-language text-muted-extra" aria-hidden="true"></i>
-                        {% for lan in item.subject_language %}
-                          {{ lan }}{{ ", " if not loop.last else "" }}
-                        {% endfor %}
-                      {%  endif %}
-                    </span>
-                    <span class="text-muted-extra">{{ item.identifier.0 }}</span>
-                  </div>
-                </a>
-
-              </li>
-            {% endfor %}
-            </ul>
-
-        </div>
-       {% endfor %}
-       <h4 style="margin-top:0">Further converted to</h4>
-       <div style="margin-left: .2rem;border-left: 1px solid #eee;padding-left:.8rem; margin-bottom: 1rem; border-bottom-left-radius: 8px;">
-        {% for medium, item_list in has_format.items() %}
-        {% for item in item_list %}
-          {% if item.has_format|length>0 %}
-            {% for rec_medium, rec_item_list in item.has_format.items() %}
-              <h5>{{ item.identifier.0 }} -> {{ rec_medium }}</h5>
-              <div class="items-listing">
-                <div class="row">
-                  <ul class="no-style-list">
-                  {% for rec_item in rec_item_list %}
-                    {% with %}
-                      {% set item = rec_item %}
-                      {% include 'component-item-in-list.html' %}
-                    {% endwith %}
-                  {% endfor %}
-                  </ul>
-                </div>
-              </div>
-            {% endfor %}
-          {% endif %}
-        {% endfor %}
-        {% endfor %}
-       </div> #}
-    {% endif %}  {# if descendants #}
+    {% endif %}  
 
     
-     {% if is_format_of|length >0 %}
+    {% if is_format_of|length >0 %}
       <hr>
-      <h2>{% trans %}Converted from{% endtrans %}</h2>
-      {% for medium, item_list in is_format_of.items() %}
-        <h3>{{ medium }}</h3>
-        <div class="items-listing">
-          <div class="row">
-            <ul class="no-style-list">
-            {% for item in item_list %}
-              {%  with %}
-                {%  include 'component-item-in-list.html' %}
-              {%  endwith %}
+      <h2>{% trans %}This item has been converted from:{% endtrans %}</h2>
+      <div class="items-listing">
+        <div class="row">
+          <ul class="no-style-list">
+            {% for medium, item_list in is_format_of.items() %}
+              {% for item in item_list %}
+                {% with %}
+                  {% include 'component-item-in-list.html' %}
+                {% endwith %}
+              {% endfor %}
             {% endfor %}
             </ul>
           </div>
         </div>
-      {% endfor %}
     {% endif %} 
 
   </div> <!-- // .main -->

--- a/templates/mlc_ucla_search/item.html
+++ b/templates/mlc_ucla_search/item.html
@@ -198,33 +198,38 @@
                   </div>
                 </a>
 
-                {% if item.has_format|length>0 %}
-                  <div style="margin-left: .2rem;border-left: 1px solid #eee;padding-left:.8rem; margin-bottom: 1rem; border-bottom-left-radius: 8px;">
-                    <h4 style="margin-top:0">Further converted to</h4>
-                    {% for rec_medium, rec_item_list in item.has_format.items() %}
-                      <h5>{{ rec_medium }}</h5>
-                      <div class="items-listing">
-                        <div class="row">
-                          <ul class="no-style-list">
-                          {% for rec_item in rec_item_list %}
-                            {% with %}
-                              {% set item = rec_item %}
-                              {% include 'component-item-in-list.html' %}
-                            {% endwith %}
-                          {% endfor %}
-                          </ul>
-                        </div>
-                      </div>
-                    {% endfor %}
-                  </div>
-                {% endif %}
               </li>
-
             {% endfor %}
             </ul>
+
         </div>
       {% endfor %}
+      <h4 style="margin-top:0">Further converted to</h4>
+      <div style="margin-left: .2rem;border-left: 1px solid #eee;padding-left:.8rem; margin-bottom: 1rem; border-bottom-left-radius: 8px;">
+        {% for medium, item_list in has_format.items() %}
+        {% for item in item_list %}
+          {% if item.has_format|length>0 %}
+            {% for rec_medium, rec_item_list in item.has_format.items() %}
+              <h5>{{ item.identifier.0 }} -> {{ rec_medium }}</h5>
+              <div class="items-listing">
+                <div class="row">
+                  <ul class="no-style-list">
+                  {% for rec_item in rec_item_list %}
+                    {% with %}
+                      {% set item = rec_item %}
+                      {% include 'component-item-in-list.html' %}
+                    {% endwith %}
+                  {% endfor %}
+                  </ul>
+                </div>
+              </div>
+            {% endfor %}
+          {% endif %}
+        {% endfor %}
+        {% endfor %}
+      </div>
     {% endif %}
+
     
     {# {% if is_format_of %}
       <hr>

--- a/templates/mlc_ucla_search/item.html
+++ b/templates/mlc_ucla_search/item.html
@@ -169,7 +169,7 @@
               <ul class="no-style-list">
               {% for medium in order_of_formats %}
                 {% if medium in formats %}
-                  {% for descendant in formats[medium] %}
+                  {% for descendant in formats[medium]|sort(attribute="identifier") %}
                     {% set item = descendant %}
                     {% include 'component-item-in-list.html' %}
                   {% endfor %}
@@ -190,7 +190,7 @@
         <div class="row">
           <ul class="no-style-list">
             {% for medium, item_list in is_format_of.items() %}
-              {% for item in item_list %}
+              {% for item in item_list|sort(attribute="identifier") %}
                 {% with %}
                   {% include 'component-item-in-list.html' %}
                 {% endwith %}

--- a/templates/mlc_ucla_search/item.html
+++ b/templates/mlc_ucla_search/item.html
@@ -153,10 +153,6 @@
       </a>&nbsp;&nbsp;&nbsp;<span class="test-muted">{{ serie.1.identifier.0 }}</span></li>
     {% endfor %}
     </ul>
-    <h2>descendants</h2>
-    <pre>{{ descendants }}</pre>
-    <h2>ancestors</h2>
-    <pre>{{ is_format_of }}</pre>
 
     {% if descendants|length >0 %}
       <h2>{% trans %}This item has been converted to the following items:{% endtrans %}</h2>
@@ -187,8 +183,6 @@
         {% endfor %}
     {% endif %}  
     
-
-    
     {% if is_format_of|length >0 %}
       <hr>
       <h2>{% trans %}This item has been converted from:{% endtrans %}</h2>
@@ -206,7 +200,6 @@
           </div>
         </div>
     {% endif %} 
-    
 
   </div> <!-- // .main -->
 {% endblock %}

--- a/templates/mlc_ucla_search/item.html
+++ b/templates/mlc_ucla_search/item.html
@@ -156,7 +156,7 @@
     
     {% if has_format %}
       <hr>
-      <h2>{% trans %}Converted to{% endtrans %}</h2>
+      <h2>{% trans %}Has been converted to{% endtrans %}</h2>
       {% for medium, item_list in has_format.items() %}
         <h3>{{ medium }}</h3>
         <div class="items-listing">

--- a/templates/mlc_ucla_search/item.html
+++ b/templates/mlc_ucla_search/item.html
@@ -169,7 +169,7 @@
               <ul class="no-style-list">
               {% for medium in order_of_formats %}
                 {% if medium in formats %}
-                  {% for descendant in formats[medium]|sort(attribute="identifier") %}
+                  {% for descendant in formats[medium] %}
                     {% set item = descendant %}
                     {% include 'component-item-in-list.html' %}
                   {% endfor %}
@@ -190,7 +190,7 @@
         <div class="row">
           <ul class="no-style-list">
             {% for medium, item_list in is_format_of.items() %}
-              {% for item in item_list|sort(attribute="identifier") %}
+              {% for item in item_list %}
                 {% with %}
                   {% include 'component-item-in-list.html' %}
                 {% endwith %}

--- a/templates/mlc_ucla_search/item.html
+++ b/templates/mlc_ucla_search/item.html
@@ -16,7 +16,7 @@
     {% endif %}
     <span class="hidden">
       {% if panopto_links %}
-        <dt>{% trans %}Panopto Links{% endtrans %}:</dt>
+        <dt>Panopto Links:</dt>
         <dd>
          {% for i in panopto_links %}
           <a href="{{ i }}">{{ i }}</a><br>
@@ -153,11 +153,36 @@
       </a>&nbsp;&nbsp;&nbsp;<span class="test-muted">{{ serie.1.identifier.0 }}</span></li>
     {% endfor %}
     </ul>
-    
-    {% if has_format %}
-      <hr>
+
+    {% if descendants|length >0 %}
       <h2>{% trans %}Has been converted to{% endtrans %}</h2>
-      {% for medium, item_list in has_format.items() %}
+      <div class="items-listing" >
+        {% for level, formats in descendants.items() %} 
+          {% if level > 1 %}
+            <div class="items-listing" style="padding-left:.5rem; border-left: 1px solid #eee;">
+          {% endif %}
+           <span class="text-muted">Gen: {{ level }}</span>
+            <div class="row">
+              <ul class="no-style-list">
+              {% for format, item_list in formats.items() %}
+                  {% for descendant in item_list %}
+                    {#
+                    <pre>{{ item }}</pre>
+                    {% set item = item_o[1] %}
+                    #}
+
+                    {% set item = descendant %}
+                    {% include 'component-item-in-list.html' %}
+                  {% endfor %}
+              {% endfor %}
+              </ul>
+            </div>
+        {% endfor %}
+        {% for level, formats in descendants.items() %}
+          </div>
+        {% endfor %}
+      {#
+       {% for medium, item_list in has_format.items() %}
         <h3>{{ medium }}</h3>
         <div class="items-listing">
             <ul class="no-style-list">
@@ -203,9 +228,9 @@
             </ul>
 
         </div>
-      {% endfor %}
-      <h4 style="margin-top:0">Further converted to</h4>
-      <div style="margin-left: .2rem;border-left: 1px solid #eee;padding-left:.8rem; margin-bottom: 1rem; border-bottom-left-radius: 8px;">
+       {% endfor %}
+       <h4 style="margin-top:0">Further converted to</h4>
+       <div style="margin-left: .2rem;border-left: 1px solid #eee;padding-left:.8rem; margin-bottom: 1rem; border-bottom-left-radius: 8px;">
         {% for medium, item_list in has_format.items() %}
         {% for item in item_list %}
           {% if item.has_format|length>0 %}
@@ -227,11 +252,11 @@
           {% endif %}
         {% endfor %}
         {% endfor %}
-      </div>
-    {% endif %}
+       </div> #}
+    {% endif %}  {# if descendants #}
 
     
-    {# {% if is_format_of %}
+     {% if is_format_of|length >0 %}
       <hr>
       <h2>{% trans %}Converted from{% endtrans %}</h2>
       {% for medium, item_list in is_format_of.items() %}
@@ -248,7 +273,7 @@
           </div>
         </div>
       {% endfor %}
-    {% endif %} #}
+    {% endif %} 
 
   </div> <!-- // .main -->
 {% endblock %}

--- a/templates/mlc_ucla_search/item.html
+++ b/templates/mlc_ucla_search/item.html
@@ -208,6 +208,7 @@
                         <ul class="no-style-list">
                         {% for rec_item in rec_item_list %}
                           {% with %}
+                            {% set item = rec_item %}
                             {% include 'component-item-in-list.html' %}
                           {% endwith %}
                         {% endfor %}

--- a/templates/mlc_ucla_search/item.html
+++ b/templates/mlc_ucla_search/item.html
@@ -153,6 +153,10 @@
       </a>&nbsp;&nbsp;&nbsp;<span class="test-muted">{{ serie.1.identifier.0 }}</span></li>
     {% endfor %}
     </ul>
+    <h2>descendants</h2>
+    <pre>{{ descendants }}</pre>
+    <h2>ancestors</h2>
+    <pre>{{ is_format_of }}</pre>
 
     {% if descendants|length >0 %}
       <h2>{% trans %}This item has been converted to the following items:{% endtrans %}</h2>
@@ -164,7 +168,7 @@
           {% elif level > 2 %}
             <div class="items-listing" style="padding:.5rem 0 0 .5rem; border-left: 1px solid #a6a6a6; border-bottom-left-radius: 8px;">
           {% endif %}
-           {# <span class="text-muted">Gen: {{ level }}</span> #}
+           <!-- <span class="text-muted">Gen: {{ level }}</span> -->
             <div class="row">
               <ul class="no-style-list">
               {% for medium in order_of_formats %}
@@ -182,6 +186,7 @@
           </div>
         {% endfor %}
     {% endif %}  
+    
 
     
     {% if is_format_of|length >0 %}
@@ -201,6 +206,7 @@
           </div>
         </div>
     {% endif %} 
+    
 
   </div> <!-- // .main -->
 {% endblock %}

--- a/templates/mlc_ucla_search/item.html
+++ b/templates/mlc_ucla_search/item.html
@@ -167,11 +167,13 @@
            {# <span class="text-muted">Gen: {{ level }}</span> #}
             <div class="row">
               <ul class="no-style-list">
-              {% for format, item_list in formats.items() %}
-                  {% for descendant in item_list %}
+              {% for medium in order_of_formats %}
+                {% if medium in formats %}
+                  {% for descendant in formats[medium] %}
                     {% set item = descendant %}
                     {% include 'component-item-in-list.html' %}
                   {% endfor %}
+                {% endif %}
               {% endfor %}
               </ul>
             </div>

--- a/templates/mlc_ucla_search/item.html
+++ b/templates/mlc_ucla_search/item.html
@@ -160,15 +160,67 @@
       {% for medium, item_list in has_format.items() %}
         <h3>{{ medium }}</h3>
         <div class="items-listing">
-          <div class="row">
             <ul class="no-style-list">
             {% for item in item_list %}
-              {%  with %}
-                {%  include 'component-item-in-list.html' %}
-              {%  endwith %}
+              <li title="{{item.titles[0]}}">
+
+                <a class="item-card" href="/item/{{ item.ark|replace('https://ark.lib.uchicago.edu/ark:61001/', '')|urlencode }}/">
+                  <div class="item-card-title-row">
+                    <span class="item-card-title">
+                      {% for title in item.titles %}
+                        {{ title }}
+                      {% endfor %}
+                    </span>
+                    {% if item.panopto_links|length > 0 %}
+                      <span title="item has digital content"><i class="item-icon fa fa-lg fa-file-audio-o" aria-hidden="true"></i></span>
+                    {% endif %}
+                  </div>
+                  <div class="item-card-content-row">
+                    <span title="Type of Media">
+                    {% for medium in item.medium %}
+                      {{ medium }}
+                    {% endfor %}
+                    </span>
+                    {% if item.has_format|length > 0 %}
+                      <span title="Item is converted to other formats">+<i class="fa fa-files-o" aria-hidden="true"></i></span>
+                    {% endif %}
+                  </div>
+                  <div class="item-card-content-row">
+                      <span title="Subject language">
+                      {% if item.subject_language %}
+                        <i class="fa fa-language text-muted-extra" aria-hidden="true"></i>
+                        {% for lan in item.subject_language %}
+                          {{ lan }}{{ ", " if not loop.last else "" }}
+                        {% endfor %}
+                      {%  endif %}
+                    </span>
+                    <span class="text-muted-extra">{{ item.identifier.0 }}</span>
+                  </div>
+                </a>
+
+                {% if item.has_format|length>0 %}
+                  <h4>Further converted to</h4>
+                  <div style="padding-left:1rem">
+                  {% for rec_medium, rec_item_list in item.has_format.items() %}
+                    <h5>{{ rec_medium }}</h5>
+                    <div class="items-listing">
+                      <div class="row">
+                        <ul class="no-style-list">
+                        {% for rec_item in rec_item_list %}
+                          {% with %}
+                            {% include 'component-item-in-list.html' %}
+                          {% endwith %}
+                        {% endfor %}
+                        </ul>
+                      </div>
+                    </div>
+                  {% endfor %}
+                  </div>
+                {% endif %}
+              </li>
+
             {% endfor %}
             </ul>
-          </div>
         </div>
       {% endfor %}
     {% endif %}

--- a/templates/mlc_ucla_search/item.html
+++ b/templates/mlc_ucla_search/item.html
@@ -225,7 +225,7 @@
       {% endfor %}
     {% endif %}
     
-    {% if is_format_of %}
+    {# {% if is_format_of %}
       <hr>
       <h2>{% trans %}Converted from{% endtrans %}</h2>
       {% for medium, item_list in is_format_of.items() %}
@@ -242,7 +242,7 @@
           </div>
         </div>
       {% endfor %}
-    {% endif %}
+    {% endif %} #}
 
   </div> <!-- // .main -->
 {% endblock %}

--- a/templates/mlc_ucla_search/search.html
+++ b/templates/mlc_ucla_search/search.html
@@ -117,10 +117,12 @@
         <div class="row">
         <ul class="no-style-list">
         {% for item_o in result.1.sub_items %}
-          {%  with %}
-            {%  set item = item_o %}
-            {%  include 'component-item-in-list.html' %}
-          {%  endwith %}
+          {% with %}
+            {% if item_o.is_format_of|length == 0 %}
+              {% set item = item_o %}
+              {% include 'component-item-in-list.html' %}
+            {% endif %}
+          {% endwith %}
         {% endfor %}
         </ul>
         </div>

--- a/templates/mlc_ucla_search/series.html
+++ b/templates/mlc_ucla_search/series.html
@@ -106,7 +106,7 @@
         <div class="items-listing">
           <div class="row">
             <ul class="no-style-list">
-            {% for item in grouped_items[medium]|sort(attribute="identifier") %}
+            {% for item in grouped_items[medium] %}
               {% include 'component-item-in-list.html' %}
             {% endfor %}
             </ul>

--- a/templates/mlc_ucla_search/series.html
+++ b/templates/mlc_ucla_search/series.html
@@ -106,9 +106,9 @@
         <div class="row">
           <ul class="no-style-list">
           {% for item in item_list %}
-            {%  with %}
-              {%  include 'component-item-in-list.html' %}
-            {%  endwith %}
+            {% if item.is_format_of|length == 0 %}
+              {% include 'component-item-in-list.html' %}
+            {% endif %}
           {% endfor %}
           </ul>
         </div>

--- a/templates/mlc_ucla_search/series.html
+++ b/templates/mlc_ucla_search/series.html
@@ -100,35 +100,19 @@
       </dl>
     </div>
     <h2>{% trans %}Items in the Series{% endtrans %}</h2>
-    {% for medium, item_list in grouped_items.items() %}
-      <h3>{{ medium }}</h3>
-      <div class="items-listing">
-        <div class="row">
-          <ul class="no-style-list">
-          {% for item in item_list %}
-            {% if item.is_format_of|length == 0 %}
+    {% for medium in order_of_formats %}
+      {% if medium in grouped_items %}
+        <h3>{{ medium }}</h3>
+        <div class="items-listing">
+          <div class="row">
+            <ul class="no-style-list">
+            {% for item in grouped_items[medium]|sort(attribute="identifier") %}
               {% include 'component-item-in-list.html' %}
-            {% endif %}
-          {% endfor %}
-          </ul>
+            {% endfor %}
+            </ul>
+          </div>
         </div>
-      </div>
+      {% endif %}
     {% endfor %}
-
-    {# <pre>{{ grouped_items }}</pre>
-
-    <h2>{% trans %}Items in the Series{% endtrans %}</h2>
-    <div class="items-listing">
-      <div class="row">
-        <ul class="no-style-list">
-        {% for i in items %}
-          {%  with %}
-            {%  set item = i.1 %}
-            {%  include 'component-item-in-list.html' %}
-          {%  endwith %}
-        {% endfor %}
-        </ul>
-      </div>
-    </div> #}
   </div> <!-- // .col-xs-12 .col-md-9 .centermain -->
 {% endblock %}

--- a/utils.py
+++ b/utils.py
@@ -1598,14 +1598,14 @@ class MLCDB:
             assert type(formats_in_level) == dict
             assert type(item_has_formats) == dict
             out = {}
-            for d in (formats_in_level, item_has_formats):
-                for k, lst in d.items():
-                    if not k in out:
-                        out[k] = set()
-                    for v in lst:
-                        out[k].add(v)
-            for k in out.keys():
-                out[k] = list(out[k])
+            for format_dict in (formats_in_level, item_has_formats):
+                for format_name, lst in format_dict.items():
+                    if not format_name in out:
+                        out[format_name] = set()
+                    for item in lst:
+                        out[format_name].add(item)
+            for out_format_name in out.keys():
+                out[out_format_name] = list(out[out_format_name])
             return out
     
         def get_has_format(i):
@@ -1672,9 +1672,13 @@ class MLCDB:
             info['descendants'] = self.get_formats_by_level(identifier)
             if 'is_format_of' in info:
                 for medium in info['is_format_of'].keys():
-                    for parent_item in range(len(info['is_format_of'][medium])):
-                        url = info['is_format_of'][medium][parent_item]
-                        info['is_format_of'][medium][parent_item] = self._item_info[url]
+                    for parent_item_index in range(len(info['is_format_of'][medium])):
+                        # identifier format: https://ark.lib.uchicago.edu/ark:61001/b29r8d35893d
+                        url = info['is_format_of'][medium][parent_item_index]
+                        if url != identifier:
+                            info['is_format_of'][medium][parent_item_index] = self._item_info[url]
+                        else:
+                            info['is_format_of'][medium].pop(parent_item_index)
 
         return info
 

--- a/utils.py
+++ b/utils.py
@@ -1594,11 +1594,11 @@ class MLCDB:
                   Each of those sub-dicts is organized by mediums, and each
                   medium contains a list of items.
         """
-        def append_dict_of_lists(a, b):
-            assert type(a) == dict
-            assert type(b) == dict
+        def append_dict_of_lists(formats_in_level, item_has_formats):
+            assert type(formats_in_level) == dict
+            assert type(item_has_formats) == dict
             out = {}
-            for d in (a, b):
+            for d in (formats_in_level, item_has_formats):
                 for k, lst in d.items():
                     if not k in out:
                         out[k] = set()
@@ -1659,13 +1659,23 @@ class MLCDB:
         info = copy.deepcopy(self._item_info[identifier])
 
         # load item hasFormat / isFormatOf relationships
+        # if get_format_relationships:
+        #     for p in ('has_format', 'is_format_of'):
+        #         if p in info:
+        #             for m in info[p].keys():
+        #                 for i in range(len(info[p][m])):
+        #                     url = info[p][m][i]
+        #                     info[p][m][i] = self._item_info[url]
+
+        # load descendants
         if get_format_relationships:
-            for p in ('has_format', 'is_format_of'):
-                if p in info:
-                    for m in info[p].keys():
-                        for i in range(len(info[p][m])):
-                            url = info[p][m][i]
-                            info[p][m][i] = self._item_info[url]
+            info['descendants'] = self.get_formats_by_level(identifier)
+            if 'is_format_of' in info:
+                for medium in info['is_format_of'].keys():
+                    for parent_item in range(len(info['is_format_of'][medium])):
+                        url = info['is_format_of'][medium][parent_item]
+                        info['is_format_of'][medium][parent_item] = self._item_info[url]
+
         return info
 
     def get_item_list(self):

--- a/utils.py
+++ b/utils.py
@@ -1679,6 +1679,10 @@ class MLCDB:
                             info['is_format_of'][medium][parent_item_index] = self._item_info[url]
                         else:
                             info['is_format_of'][medium].pop(parent_item_index)
+                for medium in list(info['is_format_of'].keys()):
+                    if len(info['is_format_of'][medium]) == 0:
+                        info['is_format_of'].pop(medium, None)
+
 
         return info
 

--- a/utils.py
+++ b/utils.py
@@ -1594,18 +1594,18 @@ class MLCDB:
                   Each of those sub-dicts is organized by mediums, and each
                   medium contains a list of items.
         """
-        def append_dict_of_lists(formats_in_level, item_has_formats):
-            assert type(formats_in_level) == dict
-            assert type(item_has_formats) == dict
+        def append_dict_of_lists(a, b):
+            assert type(a) == dict
+            assert type(b) == dict
             out = {}
-            for format_dict in (formats_in_level, item_has_formats):
-                for format_name, lst in format_dict.items():
-                    if not format_name in out:
-                        out[format_name] = set()
-                    for item in lst:
-                        out[format_name].add(item)
-            for out_format_name in out.keys():
-                out[out_format_name] = list(out[out_format_name])
+            for d in (a, b):
+                for k, lst in d.items():
+                    if not k in out:
+                        out[k] = set()
+                    for v in lst:
+                        out[k].add(v)
+            for k in out.keys():
+                out[k] = list(out[k])
             return out
     
         def get_has_format(i):


### PR DESCRIPTION
- sorted formats with a list passed through `render_template`
- sorted items within formats by `identifier` using jinja `sort()`
- reduced each item size
- replaced “item has conversions” icon with just a plus icon
- converted item names to `h3`
- Labeled only first second generations with an h2, further generations are distinguished only by visual indentation.
- removed not original formats from series view