### PR TITLE
update to access terms

### DIFF
--- a/templates/mlc_ucla_search/form-request-access.html
+++ b/templates/mlc_ucla_search/form-request-access.html
@@ -35,7 +35,7 @@
           <input type="text" class="form-control" id="item_title" name="Item Title" value="{{ request.args.get('item_title') }}" readonly required>
         </div>
         <div class="form-group">
-          <label for="requestReason">{% trans %}Please describe the reason for your request.{% endtrans %}*</label>
+          <label for="requestReason">{% trans %}Please describe the educational or fair use reason to access this series.{% endtrans %}*</label>
           <textarea type="text" class="form-control" id="requestReason" name="Series access request reason" placeholder="{% trans %}Please specify{% endtrans %}" required></textarea>
         </div>
         <button type="submit">{% trans %}Submit{% endtrans %}</button><br>

--- a/templates/ucla/static-access-terms.html
+++ b/templates/ucla/static-access-terms.html
@@ -9,12 +9,39 @@
     <div class="title-wrapper">
       <h1>{{ title_slug }}</h1>
     </div>
-    <p>This digital project makes many of these collections freely available for research use and tracks many others that can be made available for use by arrangement. For online access to the digital files, there is an access request link on each series and its items the is restricted.</p>
+    
+    {# 1. Access and Registration (Access Requirements, Accurate Representation) #}
+    {# 2. Usage and Permissions (Permitted Uses, Reproduction and Distribution, Commercial Use) #}
+    {# 3. Respect and Compliance (Respect for Materials, Access Suspension, Rights and Responsibilities) #}
+    {# 4. Academic and Depositor Guidelines (Citation Requirements, Depositor Obligations) #}
 
-    <p>Account requests are reviewed individually and typically processed within five business days, after which an email is sent with instructions on how to use the account.</p>
 
-    <p>Access to the collection is maintained by the Hanna Holborn Gray Special Collections Research Center including <a href="https://www.lib.uchicago.edu/scrc/visiting/requests/">access to physical items</a>.</p>
+    <p>Access to materials in the UChicago Online Language Catalog (OLA) is limited to pre-registered users; by registering to use the site, you agree to these Terms of Use. </p>
 
+    {# 2. Usage and Permissions (Permitted Uses, Reproduction and Distribution, Commercial Use) #}
+    <p>The materials in the OLA are strictly for use in research, teaching, and private study, and may not be used for any commercial purpose. Except as may be allowed by <a href="https://www.lib.uchicago.edu/copyrightinfo/fairuse.html">fair use</a> or other statutory exceptions, the OLA collection may not be reproduced or distributed, in whole or in part, without written authorization from the OLA.  </p>
+
+    <p>The OLA — the staff who currently steward the collection as well as the researchers who collected the materials therein — feel a deep debt of gratitude and sense of responsibility toward the consultants whose voices, music, and experiences are documented within this collection. We ask OLA users to approach these materials with an appropriate level of respect for their provenance and significance.</p>
+
+    <p><b>The OLA may at any time suspend or revoke your access to the OLA for failure to adhere to these Terms of Use, or if we have reason to believe your use is inappropriate to its purpose as a resource for scholars and community members.</b></p>
+
+    {# 3. Respect and Compliance #}
+    <p>In addition to requiring permission from the OLA for reproduction or distribution, many materials in the OLA collection are protected by copyright, or may be subject to publicity rights, privacy rights, or other legal interests of creators or persons depicted in them. Written permission of copyright owners and/or other rights holders is required for reproduction, distribution, or other use of protected materials beyond that allowed by <a href="https://www.lib.uchicago.edu/copyrightinfo/fairuse.html">fair use</a> or other statutory exceptions. Users are responsible for making an independent assessment of materials and securing any necessary permission for their use.</p>
+
+    {# 4. Academic and Depositor Guidelines #}
+    <p>In accordance with standard academic practice, if you reference OLA materials or metadata results in an article, book, or other publication, you will cite the OLA as a resource in your bibliography along with the original researcher and field information; for example: “Korku field recordings, Norman Zide et al., 1958, Online Language Archive, University of Chicago.” Please contact the OLA if you need assistance with the appropriate citation format.</p>
+
+    {# 2. Usage and Permissions #}
+    <p>Use of OLA materials for commercial purposes may be subject to a use fee and other restrictions. Contact <a href="mailto:ola@uchicago.edu">ola@uchicago.edu</a> to inquire about permission to copy or use OLA material for any commercial purposes.</p>
+
+    {# 1. Access and Registration #}
+    <p>By registering for access to the OLA, you agree that you are accurately representing your identity, qualifications, and intended use of OLA materials, and that you are solely responsible for your use of OLA materials.</p>  
+
+    {# 3. Respect and Compliance (Respect for Materials, Access Suspension, Rights and Responsibilities) #}
+    <p>If you are a copyright owner or otherwise have exclusive control of any materials you encounter in the OLA collection and do not wish to have the material made available in the OLA collection, or if you encounter material that you believe violates the legal interests of the creator of the material or a person depicted in it, please contact us immediately at <a href="mailto:ola@uchicago.edu">ola@uchicago.edu</a> so that we may address your concerns. Please identify with specificity the material to which your concern relates.</p>
+
+    {# 4. Academic and Depositor Guidelines #}
+    <p>New material deposited into the OLA collection must abide by our <a href="/acquisitions-policy">Acquisitions Policy</a>; by adding to the collection, depositors are confirming that the deposit and use of materials under these Terms of Use are in accordance with copyright law, other legal obligations, and any ethical obligations to speakers and their communities.</p>
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
Should revert changes from the previous PR https://github.com/uchicago-library/mlc_ucla/pull/52 that was done by mistake.
Changes only strings related to the terms of access narrative following recent updates.