### PR TITLE
50 update frontend after user tests

### DIFF
--- a/templates/mlc_ucla_search/base.html
+++ b/templates/mlc_ucla_search/base.html
@@ -59,7 +59,7 @@
       <div class="container">
         <div class="row">
           <div class="col-xs-12">
-            <p class="w-100">{{ trans.collection_title }}</p>
+            <a href="/"><p class="w-100">{{ trans.collection_title }}</p></a>
           </div>
         </div>
       </div>

--- a/templates/mlc_ucla_search/component-object-metadata.html
+++ b/templates/mlc_ucla_search/component-object-metadata.html
@@ -231,21 +231,23 @@
         </dd>
       {% endif %}
   </dl>
-  <div class="panel-footer" style="display: flex; flex-wrap: wrap;justify-content: space-between; align-items: flex-end; gap: 5px 15px;">
-    <div>
-      <b>Citation</b>
-      <div class="citation-text" aria-hidden="true">
-        {% if is_item %}  
-          {{ series[0][1].titles[0] }}, {{series[0][1].creator[0].split(',')[0]}}, {{series[0][1].date[0]}},
-          Online Language Archive, University of Chicago.
-        {% elif is_series %}
-          {{ titles[0] }}, {{creator[0]}}, {{date[0].split('/')[0]}},
-          Online Language Archive, University of Chicago.
-        {% endif %}
+  {% if is_item or is_series %}
+    <div class="panel-footer" style="display: flex; flex-wrap: wrap;justify-content: space-between; align-items: flex-end; gap: 5px 15px;">
+      <div>
+        <b>Citation</b>
+        <div class="citation-text" aria-hidden="true">
+          {% if is_item %}  
+            {{ series[0][1].titles[0] }}, {{series[0][1].creator[0].split(',')[0]}}, {{series[0][1].date[0]}},
+            Online Language Archive, University of Chicago.
+          {% elif is_series %}
+              {{ titles[0] }}, {{creator[0]}}, {{date[0].split('/')[0]}},
+              Online Language Archive, University of Chicago.
+          {% endif %}
+        </div>
       </div>
+      <button id="copy-citation-btn" class="btn btn-tertiary" style="margin-bottom: 0; color: black">Copy Citation</button>
     </div>
-    <button id="copy-citation-btn" class="btn btn-tertiary" style="margin-bottom: 0;">Copy Citation</button>
-  </div>
+  {% endif %}
 </div>
 <script>
   document.addEventListener('DOMContentLoaded', function() {

--- a/templates/mlc_ucla_search/component-object-title.html
+++ b/templates/mlc_ucla_search/component-object-title.html
@@ -57,7 +57,7 @@
     </div>
 
     {# TITLE #}
-    <h1 title="{% trans %}Object title{% endtrans %}: {{series[0].1.titles.0}}">
+    <h1 title="{% trans %}Object title{% endtrans %}">
       {% if not is_series and series %}
         <a href="/series/{{ series[0].0|replace('https://ark.lib.uchicago.edu/ark:61001/', '')|urlencode }}">
           {{ series[0].1.titles.0|truncate(35, True, '...') }}

--- a/templates/ucla/base.html
+++ b/templates/ucla/base.html
@@ -50,7 +50,7 @@
       <div class="container ">
         <div class="row">
           <div class="col-xs-12">
-            <p class="w-100">{{ trans.collection_title }}</p>
+            <a href="/"><p class="w-100">{{ trans.collection_title }}</p></a>
           </div>
         </div>
       </div>

--- a/utils.py
+++ b/utils.py
@@ -1950,6 +1950,41 @@ class MLCDB:
                     results.append(series_id)
             return results
 
+    def get_series_request_access_info(self, series_id):
+        """
+        Get info dict to inform the Request access to this series button for a series.
+        To be attributed to as value of request_access_button.
+
+        Parameters:
+            series_id (str): item identifier.
+
+        Returns:
+            dict: a dictionary of information.
+        """
+
+        info = self._series_info[series_id]
+        is_restricted = info.get('access_rights', [''])[0].lower() == 'restricted'
+        has_panopto = False
+        item_id = ''
+        item_title = ''
+
+        # Check if the series has an item with a panopto link
+        for item_id in self.get_items_for_series(series_id):
+            item = self.get_item(item_id)
+            if item.get('panopto_identifiers') and len(item['panopto_identifiers']) > 0:
+                has_panopto = True
+                item_id = item.get('identifier', [''])[0]
+                item_title = item.get('titles', [''])[0]
+                break
+        
+        # return request access button information
+        return {
+            'show': is_restricted and has_panopto,
+            'series_id': series_id,
+            'item_id': item_id,
+            'item_title': item_title,
+        }
+
     def get_series_info(self, series_id):
         """
         Get info dict for a series.
@@ -1960,7 +1995,10 @@ class MLCDB:
         Returns:
             dict: a dictionary of item information.
         """
-        return self._series_info[series_id]
+
+        info = self._series_info[series_id]
+        info['request_access_button'] = self.get_series_request_access_info(series_id)
+        return info
 
     def get_series_list(self):
         """


### PR DESCRIPTION
Some pages were throwing an error when an item tried to establish if a 'request access' button was required.
Centralized the logic for this button, and verified that is only checked when a series or an item page is loaded because it could become resource intensive.
Also, linked the banner to the home page.