### PR TITLE
Patch mailto href

### DIFF
--- a/templates/mlc_ucla_search/component-sidebar-right.html
+++ b/templates/mlc_ucla_search/component-sidebar-right.html
@@ -81,7 +81,7 @@
         <p>
           <a href="https://humanities.uchicago.edu/articles/2017/03/meet-staff-courtney-guerra">Courtney Guerra</a><br/>
           <em>{% trans %}Online Media Archive{% endtrans %}</em><br/>
-          <a href="dma@uchicago.edu">dma@uchicago.edu</a><br/>
+          <a href="mailto:dma@uchicago.edu">dma@uchicago.edu</a><br/>
           <a href="tel:+17737027045">(773) 702-7045</a>
         </p>
       </div>


### PR DESCRIPTION
The link on the contact us section of the sidebar that is indicating an email should be a "mailto:" href and it is not.