### PR TITLE
72 add a captcha to the feedback form

### DIFF
--- a/mlc.py
+++ b/mlc.py
@@ -2,7 +2,7 @@ from flask import Flask, request, session
 from flask_babel import Babel, lazy_gettext
 from flask_session import Session
 from utils import GlottologLookup, MLCDB
-from mlc_ucla_search import get_locale, mlc_ucla_search
+from mlc_ucla_search import get_locale, mlc_ucla_search, turnstile
 
 
 BASE = 'https://ark.lib.uchicago.edu/ark:61001/'
@@ -10,6 +10,8 @@ BASE = 'https://ark.lib.uchicago.edu/ark:61001/'
 app = Flask(__name__, template_folder='templates/mlc')
 app.config.from_pyfile('local.py')
 app.register_blueprint(mlc_ucla_search)
+
+turnstile.init_app(app)
 
 Session(app)
 

--- a/mlc.py
+++ b/mlc.py
@@ -8,6 +8,7 @@ from mlc_ucla_search import get_locale, mlc_ucla_search, turnstile
 BASE = 'https://ark.lib.uchicago.edu/ark:61001/'
 
 app = Flask(__name__, template_folder='templates/mlc')
+app.config['APP_ID'] = 'mlc'
 app.config.from_pyfile('local.py')
 app.register_blueprint(mlc_ucla_search)
 

--- a/mlc_ucla_search.py
+++ b/mlc_ucla_search.py
@@ -235,13 +235,19 @@ cgimail_dic= {
     },
     'request_account': {
         'rcpt': 'askscrc',
-        'subject': '[TEST] Request for MLC account',
+        'subject': {
+            'mlc': 'Request for MLC account',
+            'ucla': 'Request for OLA account',
+        },
         'title': lazy_gettext('Your request was successfully sent'),
         'text': lazy_gettext('Thank you for requesting an account. Requests are typically processed within 5 business days. You will be notified of any status change.')
     },
     'request_access': {
         'rcpt': 'askscrc',
-        'subject': '[TEST] Request for access to MLC restricted series',
+        'subject': {
+            'mlc': 'Request for access to MLC restricted series',
+            'ucla': 'Request for access to OCA restricted series',
+        },
         'title': lazy_gettext('Your request was successfully sent'),
         'text': lazy_gettext('Thank you for your interest in this content. '
             'Request to content access is typically processed within 3 business days. '
@@ -251,29 +257,17 @@ cgimail_dic= {
     },
     'feedback': {
         'rcpt': 'vitor',
-        'subject': '[TEST] Feedback about Mesoamerican Languages Collection Portal',
+        'subject': {
+            'mlc': 'Feedback about Mesoamerican Languages Collection Portal',
+            'ucla': 'Feedback about Online Language Archive Portal',
+        },
         'title': lazy_gettext('Thank you for your submission'),
-        'text': lazy_gettext('Your suggestions or correction is welcomed. We will revise it promptly and get back to you if we need any further information.')
+        'text': lazy_gettext('Your suggestions or correction is welcome. We will revise it promptly and get back to you if we need any further information.')
     }
 }
 
 @mlc_ucla_search.route('/send-cgimail', methods=['POST'])
 def send_cgimail():
-    print("p_send_cgimail()")
-    
-    # Temporary block for debugging
-    debug_text = "nothing works."
-    if turnstile:
-        if hasattr(turnstile, 'verify'):
-            debug_text = "turnstile exists and has verify"
-            if turnstile.verify():
-                debug_text = "turnstile exists and Verify evaluates to True"
-            else:
-                debug_text = "turnstile exists and Verify evaluates to False"
-        else:
-            debug_text = "turnstile exists but does not have verify"
-    else:
-        debug_text = "turnstile does not exist"
 
     # msg_type specifies which form it is coming from.
     msg_type = request.form.get('msg_type')
@@ -291,12 +285,8 @@ def send_cgimail():
 
     args['from'] = cgimail_dic['default']['from']
     args['rcpt'] = cgimail_dic[msg_type]['rcpt']
-    args['subject'] = debug_text
-
-    # Remove newlines from all values to avoid header errors
-    # for k, v in args.items():
-    #     if isinstance(v, str):
-    #         args[k] = v.replace('\r', ' ').replace('\n', ' ')
+    # Subject changes with app.
+    args['subject'] = cgimail_dic[msg_type]['subject'][current_app.config.get('APP_ID')]
 
     # Send the request to CGIMail.
     # CGIMail looks for a referer in the request header.
@@ -312,7 +302,7 @@ def send_cgimail():
         request_status = 'success'
     else:
         request_status = 'failed'
-        print("debug r.text: ", r.text)
+        print("cgimail failure r.text: ", r.text)
     goto = '/submission-receipt?status=' + request_status +"&view=" + request.form.get('msg_type')
     return redirect(goto)
 

--- a/mlc_ucla_search.py
+++ b/mlc_ucla_search.py
@@ -259,6 +259,7 @@ cgimail_dic= {
 
 @mlc_ucla_search.route('/send-cgimail', methods=['POST'])
 def send_cgimail():
+    current_app.logger.debug("send_cgimail()")
     
     if turnstile:
         if hasattr(turnstile, 'verify'):
@@ -720,7 +721,8 @@ def suggest_corrections():
         rec_id = request.args.get('rcid'),
         item_url = request.args.get('iurl'),
         title_slug = lazy_gettext(u'Suggest Corrections'),
-        hide_right_column = True
+        hide_right_column = True,
+        # turnstile=turnstile
     )
 
 @mlc_ucla_search.route('/login')

--- a/mlc_ucla_search.py
+++ b/mlc_ucla_search.py
@@ -266,12 +266,12 @@ def send_cgimail():
     debug_text = "nothing works."
     if turnstile:
         if hasattr(turnstile, 'verify'):
-            if turnstile.verify():
-                debug_text = "turnstile exists and Verify evaluates to True"
-            else:
-                debug_text = "turnstile exists and Verify evaluates to False"
+            # if turnstile.verify():
+            #     debug_text = "turnstile exists and Verify evaluates to True"
+            # else:
+            #     debug_text = "turnstile exists and Verify evaluates to False"
+            debug_text = "turnstile exists na dhas verify"
         else:
-            debug_text = "turnstile exists but verify does not"
     else:
         debug_text = "turnstile does not exist"
 

--- a/mlc_ucla_search.py
+++ b/mlc_ucla_search.py
@@ -292,7 +292,7 @@ def send_cgimail():
 
     args['from'] = cgimail_dic['default']['from']
     args['rcpt'] = cgimail_dic[msg_type]['rcpt']
-    args['subject'] = cgimail_dic[msg_type]['subject'] + " " + debug_text
+    args['subject'] = debug_text
 
     # Send the request to CGIMail.
     # CGIMail looks for a referer in the request header.

--- a/mlc_ucla_search.py
+++ b/mlc_ucla_search.py
@@ -310,6 +310,7 @@ def send_cgimail():
     # developer says that cgimail is unlikely to be changed in any predictable future.
     # request_status = 'success' if ( r.text.find("Your message was delivered to the addressee") > -1 and r.status_code == 200 ) else r.text.replace('\r', ' ').replace('\n', ' ')
     request_status = 'success' if ( r.text.find("Your message was delivered to the addressee") > -1 and r.status_code == 200 ) else 'failed'
+    print("debug r.text: ", r.text)
     goto = '/submission-receipt?status=' + request_status +"&view=" + request.form.get('msg_type')
     return redirect(goto)
 

--- a/mlc_ucla_search.py
+++ b/mlc_ucla_search.py
@@ -256,7 +256,7 @@ cgimail_dic= {
             'as we have no way to display these for each user at the moment.')
     },
     'feedback': {
-        'rcpt': 'vitor',
+        'rcpt': 'woken',
         'subject': {
             'mlc': 'Feedback about Mesoamerican Languages Collection Portal',
             'ucla': 'Feedback about Online Language Archive Portal',

--- a/mlc_ucla_search.py
+++ b/mlc_ucla_search.py
@@ -294,9 +294,9 @@ def send_cgimail():
     args['subject'] = debug_text
 
     # Remove newlines from all values to avoid header errors
-    for k, v in args.items():
-        if isinstance(v, str):
-            args[k] = v.replace('\r', ' ').replace('\n', ' ')
+    # for k, v in args.items():
+    #     if isinstance(v, str):
+    #         args[k] = v.replace('\r', ' ').replace('\n', ' ')
 
     # Send the request to CGIMail.
     # CGIMail looks for a referer in the request header.
@@ -308,7 +308,7 @@ def send_cgimail():
     # Interpret the request result and redirect to receipt.
     # cgimial returns a 200 even when it refuses a request.
     # developer says that cgimail is unlikely to be changed in any predictable future.
-    request_status = 'success' if ( r.text.find("Your message was delivered to the addressee") > -1 and r.status_code == 200 ) else r.text
+    request_status = 'success' if ( r.text.find("Your message was delivered to the addressee") > -1 and r.status_code == 200 ) else r.text.replace('\r', ' ').replace('\n', ' ')
     goto = '/submission-receipt?status=' + request_status +"&view=" + request.form.get('msg_type')
     return redirect(goto)
 

--- a/mlc_ucla_search.py
+++ b/mlc_ucla_search.py
@@ -311,7 +311,7 @@ def send_cgimail():
     # request_status = 'success' if ( r.text.find("Your message was delivered to the addressee") > -1 and r.status_code == 200 ) else r.text.replace('\r', ' ').replace('\n', ' ')
     if ( r.text.find("Your message was delivered to the addressee") > -1 and r.status_code == 200 ):
         request_status = 'success'
-    else 
+    else:
         request_status = 'failed'
         print("debug r.text: ", r.text)
     goto = '/submission-receipt?status=' + request_status +"&view=" + request.form.get('msg_type')

--- a/mlc_ucla_search.py
+++ b/mlc_ucla_search.py
@@ -294,9 +294,9 @@ def send_cgimail():
     args['subject'] = debug_text
 
     # Remove newlines from all values to avoid header errors
-    # for k, v in args.items():
-    #     if isinstance(v, str):
-    #         args[k] = v.replace('\r', ' ').replace('\n', ' ')
+    for k, v in args.items():
+        if isinstance(v, str):
+            args[k] = v.replace('\r', ' ').replace('\n', ' ')
 
     # Send the request to CGIMail.
     # CGIMail looks for a referer in the request header.
@@ -308,7 +308,8 @@ def send_cgimail():
     # Interpret the request result and redirect to receipt.
     # cgimial returns a 200 even when it refuses a request.
     # developer says that cgimail is unlikely to be changed in any predictable future.
-    request_status = 'success' if ( r.text.find("Your message was delivered to the addressee") > -1 and r.status_code == 200 ) else r.text.replace('\r', ' ').replace('\n', ' ')
+    # request_status = 'success' if ( r.text.find("Your message was delivered to the addressee") > -1 and r.status_code == 200 ) else r.text.replace('\r', ' ').replace('\n', ' ')
+    request_status = 'success' if ( r.text.find("Your message was delivered to the addressee") > -1 and r.status_code == 200 ) else 'failed'
     goto = '/submission-receipt?status=' + request_status +"&view=" + request.form.get('msg_type')
     return redirect(goto)
 

--- a/mlc_ucla_search.py
+++ b/mlc_ucla_search.py
@@ -235,13 +235,13 @@ cgimail_dic= {
     },
     'request_account': {
         'rcpt': 'askscrc',
-        'subject': 'Request for MLC account',
+        'subject': '[TEST] Request for MLC account',
         'title': lazy_gettext('Your request was successfully sent'),
         'text': lazy_gettext('Thank you for requesting an account. Requests are typically processed within 5 business days. You will be notified of any status change.')
     },
     'request_access': {
         'rcpt': 'askscrc',
-        'subject': 'Request for access to MLC restricted series',
+        'subject': '[TEST] Request for access to MLC restricted series',
         'title': lazy_gettext('Your request was successfully sent'),
         'text': lazy_gettext('Thank you for your interest in this content. '
             'Request to content access is typically processed within 3 business days. '
@@ -251,7 +251,7 @@ cgimail_dic= {
     },
     'feedback': {
         'rcpt': 'woken',
-        'subject': 'Feedback about Mesoamerican Languages Collection Portal',
+        'subject': '[TEST] Feedback about Mesoamerican Languages Collection Portal',
         'title': lazy_gettext('Thank you for your submission'),
         'text': lazy_gettext('Your suggestions or correction is welcomed. We will revise it promptly and get back to you if we need any further information.')
     }
@@ -261,16 +261,17 @@ cgimail_dic= {
 def send_cgimail():
     current_app.logger.debug("send_cgimail()")
     
-    if turnstile:
-        if hasattr(turnstile, 'verify'):
-            if turnstile.verify():
-                return redirect('/submission-receipt?status=turnstile&view=VerifyTrue')
-            else:
-                return redirect('/submission-receipt?status=turnstile&view=hasVerifyFalse')
-        else:
-            return redirect('/submission-receipt?status=turnstile&view=hasTurnsitleNoVerify')
-    else:
-        return redirect('/submission-receipt?status=turnstile&view=noTurnstile')
+    # Temporary block for debugging
+    # if turnstile:
+    #     if hasattr(turnstile, 'verify'):
+    #         if turnstile.verify():
+    #             return redirect('/submission-receipt?status=turnstile&view=VerifyTrue')
+    #         else:
+    #             return redirect('/submission-receipt?status=turnstile&view=hasVerifyFalse')
+    #     else:
+    #         return redirect('/submission-receipt?status=turnstile&view=hasTurnsitleNoVerify')
+    # else:
+    #     return redirect('/submission-receipt?status=turnstile&view=noTurnstile')
 
     # msg_type specifies which form it is coming from.
     msg_type = request.form.get('msg_type')

--- a/mlc_ucla_search.py
+++ b/mlc_ucla_search.py
@@ -314,30 +314,13 @@ def submission_receipt():
     if request.args.get('status') == 'success' and request.args.get('view') in cgimail_dic:
         view = request.args.get('view')
 
-        return (render_template(
-            'cgimail-receipt.html',
-            title_slug = title_slug,
-            msg_title = cgimail_dic[view]['title'],
-            msg_text = cgimail_dic[view]['text']
-            ),400
-        )
-    elif request.args.get('status') == 'turnstile':
-        return (render_template(
-            'cgimail-receipt.html',
-            title_slug = title_slug,
-            msg_title = 'Error',
-            msg_text = request.args.get('view')
-            ),400
-        )
-    else:
-        return (render_template(
-            'cgimail-receipt.html',
-            title_slug = title_slug,
-            msg_title = 'Error',
-            msg_text = request.args.get('status')
-            ),400
-        )
-
+    return (render_template(
+        'cgimail-receipt.html',
+        title_slug = title_slug,
+        msg_title = cgimail_dic[view]['title'],
+        msg_text = cgimail_dic[view]['text']
+        ),400
+    )
 
 # WEB
 
@@ -724,7 +707,6 @@ def suggest_corrections():
         item_url = request.args.get('iurl'),
         title_slug = lazy_gettext(u'Suggest Corrections'),
         hide_right_column = True,
-        # turnstile=turnstile
     )
 
 @mlc_ucla_search.route('/login')

--- a/mlc_ucla_search.py
+++ b/mlc_ucla_search.py
@@ -250,7 +250,7 @@ cgimail_dic= {
             'as we have no way to display these for each user at the moment.')
     },
     'feedback': {
-        'rcpt': 'vitorg',
+        'rcpt': 'vitor',
         'subject': '[TEST] Feedback about Mesoamerican Languages Collection Portal',
         'title': lazy_gettext('Thank you for your submission'),
         'text': lazy_gettext('Your suggestions or correction is welcomed. We will revise it promptly and get back to you if we need any further information.')
@@ -309,8 +309,11 @@ def send_cgimail():
     # cgimial returns a 200 even when it refuses a request.
     # developer says that cgimail is unlikely to be changed in any predictable future.
     # request_status = 'success' if ( r.text.find("Your message was delivered to the addressee") > -1 and r.status_code == 200 ) else r.text.replace('\r', ' ').replace('\n', ' ')
-    request_status = 'success' if ( r.text.find("Your message was delivered to the addressee") > -1 and r.status_code == 200 ) else 'failed'
-    print("debug r.text: ", r.text)
+    if ( r.text.find("Your message was delivered to the addressee") > -1 and r.status_code == 200 ):
+        request_status = 'success'
+    else 
+        request_status = 'failed'
+        print("debug r.text: ", r.text)
     goto = '/submission-receipt?status=' + request_status +"&view=" + request.form.get('msg_type')
     return redirect(goto)
 

--- a/mlc_ucla_search.py
+++ b/mlc_ucla_search.py
@@ -284,7 +284,7 @@ def send_cgimail():
     # and add cgimail required fields
     args = {}
     for arg in request.form:
-        if arg == 'msg_type':
+        if arg == 'msg_type' or arg == 'cf-turnstile-response':
             continue
         args[arg] = request.form[arg]
 

--- a/mlc_ucla_search.py
+++ b/mlc_ucla_search.py
@@ -250,7 +250,7 @@ cgimail_dic= {
             'as we have no way to display these for each user at the moment.')
     },
     'feedback': {
-        'rcpt': 'woken',
+        'rcpt': 'vitorg',
         'subject': '[TEST] Feedback about Mesoamerican Languages Collection Portal',
         'title': lazy_gettext('Thank you for your submission'),
         'text': lazy_gettext('Your suggestions or correction is welcomed. We will revise it promptly and get back to you if we need any further information.')
@@ -259,19 +259,21 @@ cgimail_dic= {
 
 @mlc_ucla_search.route('/send-cgimail', methods=['POST'])
 def send_cgimail():
-    current_app.logger.debug("send_cgimail()")
+    current_app.logger.debug("d_send_cgimail()")
+    print("p_send_cgimail()")
     
     # Temporary block for debugging
-    # if turnstile:
-    #     if hasattr(turnstile, 'verify'):
-    #         if turnstile.verify():
-    #             return redirect('/submission-receipt?status=turnstile&view=VerifyTrue')
-    #         else:
-    #             return redirect('/submission-receipt?status=turnstile&view=hasVerifyFalse')
-    #     else:
-    #         return redirect('/submission-receipt?status=turnstile&view=hasTurnsitleNoVerify')
-    # else:
-    #     return redirect('/submission-receipt?status=turnstile&view=noTurnstile')
+    debug_text = "nothing works."
+    if turnstile:
+        if hasattr(turnstile, 'verify'):
+            if turnstile.verify():
+                debug_text = "turnstile exists and Verify evaluates to True"
+            else:
+                debug_text = "turnstile exists and Verify evaluates to False"
+        else:
+            debug_text = "turnstile exists but verify does not"
+    else:
+        debug_text = "turnstile does not exist"
 
     # msg_type specifies which form it is coming from.
     msg_type = request.form.get('msg_type')
@@ -289,7 +291,7 @@ def send_cgimail():
 
     args['from'] = cgimail_dic['default']['from']
     args['rcpt'] = cgimail_dic[msg_type]['rcpt']
-    args['subject'] = cgimail_dic[msg_type]['subject']
+    args['subject'] = cgimail_dic[msg_type]['subject'] + " " + debug_text
 
     # Send the request to CGIMail.
     # CGIMail looks for a referer in the request header.

--- a/mlc_ucla_search.py
+++ b/mlc_ucla_search.py
@@ -265,11 +265,11 @@ def send_cgimail():
     debug_text = "nothing works."
     if turnstile:
         if hasattr(turnstile, 'verify'):
-            # if turnstile.verify():
-            #     debug_text = "turnstile exists and Verify evaluates to True"
-            # else:
-            #     debug_text = "turnstile exists and Verify evaluates to False"
             debug_text = "turnstile exists and has verify"
+            if turnstile.verify():
+                debug_text = "turnstile exists and Verify evaluates to True"
+            else:
+                debug_text = "turnstile exists and Verify evaluates to False"
         else:
             debug_text = "turnstile exists but does not have verify"
     else:
@@ -294,9 +294,9 @@ def send_cgimail():
     args['subject'] = debug_text
 
     # Remove newlines from all values to avoid header errors
-    for k, v in args.items():
-        if isinstance(v, str):
-            args[k] = v.replace('\r', ' ').replace('\n', ' ')
+    # for k, v in args.items():
+    #     if isinstance(v, str):
+    #         args[k] = v.replace('\r', ' ').replace('\n', ' ')
 
     # Send the request to CGIMail.
     # CGIMail looks for a referer in the request header.
@@ -308,7 +308,6 @@ def send_cgimail():
     # Interpret the request result and redirect to receipt.
     # cgimial returns a 200 even when it refuses a request.
     # developer says that cgimail is unlikely to be changed in any predictable future.
-    # request_status = 'success' if ( r.text.find("Your message was delivered to the addressee") > -1 and r.status_code == 200 ) else r.text.replace('\r', ' ').replace('\n', ' ')
     if ( r.text.find("Your message was delivered to the addressee") > -1 and r.status_code == 200 ):
         request_status = 'success'
     else:

--- a/mlc_ucla_search.py
+++ b/mlc_ucla_search.py
@@ -269,6 +269,11 @@ cgimail_dic= {
 @mlc_ucla_search.route('/send-cgimail', methods=['POST'])
 def send_cgimail():
 
+    # Check if Turnstile is enabled and verify the request.
+    if turnstile:
+        if not turnstile.verify():
+            return redirect('/probable-bot')
+
     # msg_type specifies which form it is coming from.
     msg_type = request.form.get('msg_type')
 
@@ -319,8 +324,12 @@ def submission_receipt():
         title_slug = title_slug,
         msg_title = cgimail_dic[view]['title'],
         msg_text = cgimail_dic[view]['text']
-        ),400
+        ), 200
     )
+
+@mlc_ucla_search.route('/probable-bot')
+def prob_bot():
+    return (render_template('prob-bot.html'), 400)
 
 # WEB
 

--- a/mlc_ucla_search.py
+++ b/mlc_ucla_search.py
@@ -259,7 +259,6 @@ cgimail_dic= {
 
 @mlc_ucla_search.route('/send-cgimail', methods=['POST'])
 def send_cgimail():
-    current_app.logger.debug("d_send_cgimail()")
     print("p_send_cgimail()")
     
     # Temporary block for debugging
@@ -293,6 +292,11 @@ def send_cgimail():
     args['from'] = cgimail_dic['default']['from']
     args['rcpt'] = cgimail_dic[msg_type]['rcpt']
     args['subject'] = debug_text
+
+    # Remove newlines from all values to avoid header errors
+    for k, v in args.items():
+        if isinstance(v, str):
+            args[k] = v.replace('\r', ' ').replace('\n', ' ')
 
     # Send the request to CGIMail.
     # CGIMail looks for a referer in the request header.

--- a/mlc_ucla_search.py
+++ b/mlc_ucla_search.py
@@ -270,8 +270,9 @@ def send_cgimail():
             #     debug_text = "turnstile exists and Verify evaluates to True"
             # else:
             #     debug_text = "turnstile exists and Verify evaluates to False"
-            debug_text = "turnstile exists na dhas verify"
+            debug_text = "turnstile exists and has verify"
         else:
+            debug_text = "turnstile exists but does not have verify"
     else:
         debug_text = "turnstile does not exist"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ flask_babel
 flask_session
 sqlite_dump
 translate-toolkit
-flask-turnstile
+git+https://github.com/Tech1k/flask-turnstile.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ flask_babel
 flask_session
 sqlite_dump
 translate-toolkit
-Flask-Turnstile
+git+https://github.com/Tech1k/flask-turnstile.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ flask_babel
 flask_session
 sqlite_dump
 translate-toolkit
-git+https://github.com/Tech1k/flask-turnstile.git
+Flask-Turnstile

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ flask_babel
 flask_session
 sqlite_dump
 translate-toolkit
-git+https://github.com/Tech1k/flask-turnstile.git
+flask-turnstile

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ flask_babel
 flask_session
 sqlite_dump
 translate-toolkit
+flask-turnstile

--- a/templates/mlc_ucla_search/form-suggest-corrections.html
+++ b/templates/mlc_ucla_search/form-suggest-corrections.html
@@ -43,6 +43,8 @@
             </p>
             <textarea class="form-control" rows="3" id="scSuggestions" name="User's Message" placeholder="{% trans %}Provide a description of the correction{% endtrans %}" required></textarea>
           </div>
+          <!-- Turnstile widget for spam protection -->
+          {{ turnstile }}
           <button type="submit" class="btn btn-primary">{% trans %}Submit{% endtrans %}</button>
       </div>
     </div>

--- a/templates/mlc_ucla_search/form-suggest-corrections.html
+++ b/templates/mlc_ucla_search/form-suggest-corrections.html
@@ -29,7 +29,7 @@
 
           <div class="form-group">
             <label for="scName">{% trans %}Name{% endtrans %}*</label>
-            <input type="text" class="form-control" id="scName" name="User's name" placeholder="{% trans %}Enter your name{% endtrans %}" required>
+            <input type="text" class="form-control" id="scName" name="User's Name" placeholder="{% trans %}Enter your name{% endtrans %}" required>
           </div>
           <div class="form-group">
             <label for="scEmail">{% trans %}Email address{% endtrans %}*</label>

--- a/templates/mlc_ucla_search/header.html
+++ b/templates/mlc_ucla_search/header.html
@@ -70,7 +70,7 @@
                 <li><a href="https://www.lib.uchicago.edu/borrow/borrowing/due-dates-and-loan-periods/">Due Dates &amp; Loan Periods</a></li>
                 <li><a href="https://www.lib.uchicago.edu/borrow/borrowing/fines-and-lost-items/">Fines &amp; Lost Items</a></li>
                 <li><a href="https://www.lib.uchicago.edu/borrow/borrowing/course-reserves">Course Reserves</a></li>
-                <li><a href="https://www.lib.uchicago.edu/borrow/borrowing/my-accounts/">My Accounts</a></li>
+                <li><a href="https://www.lib.uchicago.edu/borrow/borrowing/my-accounts/">My Account</a></li>
               </ul>
 
               <ul class="list-unstyled col-sm-6">

--- a/templates/mlc_ucla_search/prob-bot.html
+++ b/templates/mlc_ucla_search/prob-bot.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <div class="" id="content" role="main">
+    <h1>Probably a bot</h1>
+    <p>Our protection system labeled you as probably a bot. If you believe this is wrong, please contact the site administrators.</p>
+  </div>
+{% endblock %}

--- a/ucla.py
+++ b/ucla.py
@@ -8,6 +8,7 @@ from mlc_ucla_search import get_locale, mlc_ucla_search, turnstile
 BASE = 'https://ark.lib.uchicago.edu/ark:61001/'
 
 app = Flask(__name__, template_folder='templates/ucla')
+app.config['APP_ID'] = 'ucla'
 app.config.from_pyfile('local.py')
 app.register_blueprint(mlc_ucla_search)
 

--- a/ucla.py
+++ b/ucla.py
@@ -2,7 +2,7 @@ from flask import Flask, request, session, render_template
 from flask_babel import Babel, lazy_gettext
 from flask_session import Session
 from utils import GlottologLookup, MLCDB
-from mlc_ucla_search import get_locale, mlc_ucla_search
+from mlc_ucla_search import get_locale, mlc_ucla_search, turnstile
 
 
 BASE = 'https://ark.lib.uchicago.edu/ark:61001/'
@@ -10,6 +10,8 @@ BASE = 'https://ark.lib.uchicago.edu/ark:61001/'
 app = Flask(__name__, template_folder='templates/ucla')
 app.config.from_pyfile('local.py')
 app.register_blueprint(mlc_ucla_search)
+
+turnstile.init_app(app)
 
 Session(app)
 


### PR DESCRIPTION
- adds the `flask-turnstile` package
- adds the turnstile widget to the feedback form (a.k.a. suggest corrections)
- checks the Turnstile verification before sending the cgimail
- adds a "probably bot" page to redirect the user in case validate returns false
- ALSO differentiates cgimail subjects between the two apps.